### PR TITLE
fix(api): update reset password endpoint to PUT

### DIFF
--- a/web/apps/web-ele/src/api/core/user.ts
+++ b/web/apps/web-ele/src/api/core/user.ts
@@ -180,11 +180,9 @@ export async function batchUpdateUserStatusApi(
  */
 export async function resetUserPasswordApi(
   userId: string,
-  data: UserPasswordResetInput,
 ) {
-  return requestClient.post<User>(
-    `/api/core/user/reset/password/${userId}`,
-    data,
+  return requestClient.put<User>(
+    `/api/core/user/reset/password/${userId}`
   );
 }
 

--- a/web/apps/web-ele/src/views/_core/user/index.vue
+++ b/web/apps/web-ele/src/views/_core/user/index.vue
@@ -148,10 +148,7 @@ function onResetPassword(row: User) {
   )
     .then(async () => {
       try {
-        await resetUserPasswordApi(row.id, {
-          new_password: 'admin123',
-          confirm_password: 'admin123',
-        });
+        await resetUserPasswordApi(row.id);
         ElMessage.success($t('user.resetPasswordSuccess', [row.name]));
       } catch {
         ElMessage.error($t('user.resetPasswordError'));


### PR DESCRIPTION
## Description

<!-- Please describe the change as necessary. If it's a feature or enhancement please be as detailed as possible. If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

 -->

<!-- You can also add additional context here -->
### 问题背景
/system/user下无法重置用户密码，原有的“重置用户密码”功能使用的接口地址与请求方式与后端当前实际提供的接口不一致。前端仍采用旧的接口路径及提交方式进行请求，在与后端联调过程中容易出现接口无法访问或请求被拒绝的问题。
且前端提示的默认密码和后端密码不符

### 修改内容
Frontend (Vue/TypeScript)
将前端请求的接口地址修改为与后端保持一致的新路径，并将请求方式统一调整为 `PUT`，去除了不需要传输的信息，调整了`web\apps\web-ele\src\locales\langs`中各类语言的提示信息


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
